### PR TITLE
Fix to run proof generation with docker

### DIFF
--- a/.env.generator
+++ b/.env.generator
@@ -1,2 +1,2 @@
-WEBSOCKET=wss://testnet-rpc.zkverify.io
+WEBSOCKET=ws://testnet-rpc.zkverify.io
 SEED_PHRASE="INSERT_SEED_PHRASE"

--- a/src/proof-generator/Dockerfile
+++ b/src/proof-generator/Dockerfile
@@ -10,9 +10,11 @@ COPY .env.generator ./
 
 COPY src/utils ./src/utils
 
+COPY src/config.ts ./src/config.ts 
+
 COPY src/proof-generator ./src/proof-generator
 
 ENV INTERVAL=5
 ENV DURATION=60
 
-CMD ["npm", "run", "generate:groth16"]
+CMD ["npm", "run", "generate:proofs"]

--- a/src/proof-generator/README.md
+++ b/src/proof-generator/README.md
@@ -113,7 +113,7 @@ docker build -t proof-generator -f src/proof-generator/Dockerfile .
 ```
 3. Run the container and pass in the interval and duration (1 proof every INTERVAL for DURATION):
 ```shell
-docker run -e INTERVAL=10 -e DURATION=120 proof-generator
+docker run -it -e INTERVAL=10 -e DURATION=120 proof-generator
 ```
 
 ## Notes


### PR DESCRIPTION
This PR contains small fixes to run the proof generator application with docker, specifically they are:

- `Dockerfile` - `config.ts` file added to container 
- `Dockerfile` - script used is `generate:proofs` instead of `generate:groth16`
- `.env.generator` - `WEBSOCKET` default value is now `ws://testnet-rpc.zkverify.io `